### PR TITLE
Update imagestreams for RHEL 8.5

### DIFF
--- a/openshift/templates/nginx.json
+++ b/openshift/templates/nginx.json
@@ -1,6 +1,6 @@
 {
   "kind": "Template",
-  "apiVersion": "v1",
+  "apiVersion": "template.openshift.io/v1",
   "metadata": {
     "name": "nginx-example",
     "annotations": {
@@ -21,7 +21,7 @@
   "objects": [
     {
       "kind": "Service",
-      "apiVersion": "v1",
+      "apiVersion": "core/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
@@ -43,7 +43,7 @@
     },
     {
       "kind": "Route",
-      "apiVersion": "v1",
+      "apiVersion": "route.openshift.io/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
@@ -60,7 +60,7 @@
     },
     {
       "kind": "ImageStream",
-      "apiVersion": "v1",
+      "apiVersion": "image.openshift.io/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
@@ -70,7 +70,7 @@
     },
     {
       "kind": "BuildConfig",
-      "apiVersion": "v1",
+      "apiVersion": "build.openshift.io/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
@@ -127,7 +127,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {

--- a/openshift/templates/nginx.json
+++ b/openshift/templates/nginx.json
@@ -226,9 +226,9 @@
     {
       "name": "NGINX_VERSION",
       "displayName": "NGINX Version",
-      "description": "Version of NGINX image to be used (1.16-el8 by default).",
+      "description": "Version of NGINX image to be used (1.20-el8 by default).",
       "required": true,
-      "value": "1.16-el8"
+      "value": "1.20-el8"
     },
     {
       "name": "MEMORY_LIMIT",


### PR DESCRIPTION
- Update template to 1.20
- Use groupified apiVersion

Depends on https://github.com/sclorg/nginx-container/pull/163 to provide the new imagestream.