### PR TITLE
Relax apiVersion for core/v1

### DIFF
--- a/openshift/templates/nginx.json
+++ b/openshift/templates/nginx.json
@@ -21,7 +21,7 @@
   "objects": [
     {
       "kind": "Service",
-      "apiVersion": "core/v1",
+      "apiVersion": "v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {


### PR DESCRIPTION
Only implicit *.openshift.io/v1 are deprecated.

This is a follow-up to https://github.com/sclorg/nginx-ex/pull/21
