### PR TITLE
Bug 2104355: Replace 1.20-ubi8 with 1.20-el8 as the default image version against Nginx template

### DIFF
--- a/openshift/templates/nginx.json
+++ b/openshift/templates/nginx.json
@@ -226,9 +226,9 @@
     {
       "name": "NGINX_VERSION",
       "displayName": "NGINX Version",
-      "description": "Version of NGINX image to be used (1.20-el8 by default).",
+      "description": "Version of NGINX image to be used (1.20-ubi8 by default).",
       "required": true,
-      "value": "1.20-el8"
+      "value": "1.20-ubi8"
     },
     {
       "name": "MEMORY_LIMIT",


### PR DESCRIPTION
…Nginx template

These days OpenShift does not create ImageStreamTag based on xxxx-el8 now, so use xxxx-ubi8 by default instead of it.
Reference: https://bugzilla.redhat.com/show_bug.cgi?id=2104355