### PR TITLE
Fix test suite to support the latest API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
-.PHONY: test-openshift-4
-test-openshift-4:
-	cd tests && PYTHONPATH=$(CURDIR) python3 -m pytest --verbose --color=yes --showlocals .
+.PHONY: test-openshift-pytest
+test-openshift-pytest:
+	cd tests && PYTHONPATH=$(CURDIR) python3.12 -m pytest -s -rA --showlocals -vv test_nginx*.py

--- a/tests/test_nginx.py
+++ b/tests/test_nginx.py
@@ -18,7 +18,7 @@ class TestNginxExTemplate:
         json_raw_file = self.oc_api.get_raw_url_for_json(
             container="nginx-container", dir="imagestreams", filename="nginx-rhel.json"
         )
-        self.oc_api.import_is(path=json_raw_file, name="nginx")
+        self.oc_api.import_is(path=json_raw_file, name="nginx", skip_check=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()
@@ -31,20 +31,7 @@ class TestNginxExTemplate:
             template=template_json, name_in_template="nginx-example", expected_output="Welcome to your static nginx application",
             openshift_args=["SOURCE_REPOSITORY_REF=master", f"NGINX_VERSION={VERSION}", "NAME=nginx-example"]
         )
-        assert self.oc_api.template_deployed(name_in_template="nginx-example")
+        assert self.oc_api.is_template_deployed(name_in_template="nginx-example")
         assert self.oc_api.check_response_inside_cluster(
-            name_in_template="nginx-example", expected_output="Welcome to your static nginx application"
-        )
-
-    def test_template_by_request(self):
-        template_json = self.oc_api.get_raw_url_for_json(
-            container="nginx-ex", dir="openshift/templates", filename="nginx.json"
-        )
-        assert self.oc_api.deploy_template(
-            template=template_json, name_in_template="nginx-example", expected_output="Welcome to your static nginx application",
-            openshift_args=["SOURCE_REPOSITORY_REF=master", f"NGINX_VERSION={VERSION}", "NAME=nginx-example"]
-        )
-        assert self.oc_api.template_deployed(name_in_template="nginx-example")
-        assert self.oc_api.check_response_outside_cluster(
             name_in_template="nginx-example", expected_output="Welcome to your static nginx application"
         )


### PR DESCRIPTION
Fix test suite to support the latest API

Remove also testing template outside of cluster.
It does not make sense for sanity tests

