### PR TITLE
fix the trailing whitespace from the image name

### DIFF
--- a/openshift/templates/nginx.json
+++ b/openshift/templates/nginx.json
@@ -159,7 +159,7 @@
             "containers": [
               {
                 "name": "nginx-example",
-                "image": " ",
+                "image": "",
                 "ports": [
                   {
                     "containerPort": 8080


### PR DESCRIPTION
Deployment of `nginx-example` on Red Hat Sandbox Openshift (4.20.14) was failing to admit pods with:

```
Pod "nginx-example-675cc5bc44-78dpt" is invalid:
spec.containers[0].image: Invalid value: " ": must not have leading or trailing whitespace
```

Looks like the `image` field in the deployment file contained a trailing whitespace, which Kubernetes rejects.